### PR TITLE
Remove createJSModules override annotation

### DIFF
--- a/android/app/src/main/java/io/rnkit/alertview/AlertViewPackage.java
+++ b/android/app/src/main/java/io/rnkit/alertview/AlertViewPackage.java
@@ -21,7 +21,6 @@ public class AlertViewPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new AlertViewModule(reactContext));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return  Collections.emptyList();
     }


### PR DESCRIPTION
`createJSModules` has been removed since RN 0.47. Removal of the `@Override` annotation allows running the code on RN 0.47 and older versions.